### PR TITLE
Fix Error handling for the following two case.

### DIFF
--- a/lib/json/patch.rb
+++ b/lib/json/patch.rb
@@ -97,7 +97,7 @@ module JSON
     end
 
     def add_object(target_doc, target_item, ref_token, value)
-      raise JSON::PatchError if target_item.nil? 
+      raise JSON::PatchError if (target_item.nil? || !(Hash === target_item))
       if ref_token.nil?
         target_doc.replace(value)
       else
@@ -130,8 +130,10 @@ module JSON
 
       if Array === target_item
         target_item.delete_at ref_token.to_i if valid_index?(target_item, ref_token)
-      else
+      elsif Hash === target_item
         target_item.delete ref_token
+      else
+        raise JSON::PatchError
       end
     end
 

--- a/test/json-patch_test.rb
+++ b/test/json-patch_test.rb
@@ -121,6 +121,17 @@ describe "Section 4.1: The add operation" do
     end
   end
 
+  describe "the target location MUST reference" do
+    let(:target_document) { %q'{"foo":"bar","baz":"wat"}' }
+    let(:operation_document) { %q'[{ "op": "add", "path": "/baz/quux", "value": "qux" }]' }
+
+    it "will raise exception if the target location is string (neither an array nor object)" do
+      assert_raises(JSON::PatchError) do
+        JSON.patch(target_document, operation_document)
+      end
+    end
+  end
+
 =begin
 TODO
 When the operation is applied, the target location MUST reference one of:
@@ -175,6 +186,18 @@ describe "Section 4.2: The remove operation" do
       end
     end
   end
+
+  describe "The target location MUST exist for the operation to be successful." do
+    let(:target_document) { %q'{"foo":"bar","baz":"qux"}' }
+    let(:operation_document) { %q'[{ "op": "remove", "path": "/foo/baz" }]' }
+
+    it "will rails an exception if the member in the path does not exist" do
+      assert_raises(JSON::PatchError) do
+       JSON.patch(target_document, operation_document)
+      end
+    end
+  end
+
 
 end
 


### PR DESCRIPTION
4.1.  add
When the operation is applied, the target location MUST reference

4.2. remove
The target location MUST exist for the operation to be successful.